### PR TITLE
add contributing.md and associated documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 
-* * *
+---
 
 # CPP_BIDS
 
@@ -82,6 +82,13 @@ sub-090/ses-003/sub-090_ses-003_task-auditoryTask_run-023_events_date-2020072915
 ## Contributing
 
 Feel free to open issues to report a bug and ask for improvements.
+
+If you want to contribute, have a look at our
+[contributing guidelines](https://github.com/cpp-lln-lab/.github/blob/main/CONTRIBUTING.md)
+that are meant to guide you and help you get started. If something is not clear
+or you get stuck: it is more likely we did not do good enough a job at
+explaining things. So do not hesitate to open an issue, just to ask for
+clarification.
 
 ### Guidestyle
 


### PR DESCRIPTION
This is meant to create a document to centralize all the "HOW TO" for people who want to contribute to this repo:

- for code style guide / quality
- for unit testing
- for dealing with pull requests...

In case you want to see it in an easier format: this is adapted from the one in the BIDS specs: https://github.com/bids-standard/bids-specification/blob/master/CONTRIBUTING.md .

At the moment there are large chunks and are commented out (as they do not apply this repo).

And there are several TODOs.

I think it would be nice to have this document up in the `dev` branch and then we can update it bit by bit.

## For reviewers

- Does this make sense ? Anything else that your past or present self is unclear that could help to have here.
- Anything that should be added in here? Maybe just as a TODO for now.

### Ideas

- Is there any content from the Turing-Way we can reuse?
- I think that once we have a working basis on this one, we could adapt it for the other repos (CPP_SPM, CPP_PTB): though something smarter would be to have a separate repo with only this document and all repos point to it. This way there is an organization wide documentation and we only have to keep one document updated and not one per repo.