### PR TITLE
suppress warnings when verbose==0

### DIFF
--- a/src/saveEventsFile.m
+++ b/src/saveEventsFile.m
@@ -284,7 +284,7 @@ function logFile = checkExtracolumns(logFile, iEvent, cfg)
 
         logFile(iEvent).(namesExtraColumns{iExtraColumn}) = data;
 
-        if ~ischar(data) && any(isnan(data))
+        if ~ischar(data) && any(isnan(data)) && cfg.verbose > 0
             warning('saveEventsFile:missingData', ...
                     'Missing some %s data for this event.', namesExtraColumns{iExtraColumn});
 
@@ -292,7 +292,7 @@ function logFile = checkExtracolumns(logFile, iEvent, cfg)
                 disp(logFile(iEvent));
             end
 
-        elseif ~ischar(data) && all(isnan(data))
+        elseif ~ischar(data) && all(isnan(data)) && cfg.verbose > 0
             warning('Missing %s data for this event.', namesExtraColumns{iExtraColumn});
 
             if cfg.verbose > 1
@@ -402,7 +402,7 @@ function logFile = saveToLogFile(logFile, cfg)
         end
 
         % now save the event to log file (if not skipping)
-        if skipEvent
+        if skipEvent && cfg.verbose > 0
 
             warning(warningMessageID, warningMessage);
 

--- a/tests/test_saveEventsFileSave.m
+++ b/tests/test_saveEventsFileSave.m
@@ -52,7 +52,7 @@ function test_saveEventsFileSaveSkipEmptyEvents()
 
     [cfg, logFile] = setUp();
 
-    cfg.verbose = false;
+    cfg.verbose = 1;
 
     % create the events file and header
     logFile = saveEventsFile('open', cfg, logFile);
@@ -144,7 +144,7 @@ function test_saveEventsFileSaveArraySize()
 
     [cfg, logFile] = setUp();
 
-    cfg.verbose = false;
+    cfg.verbose = 1;
 
     % create the events file and header
     logFile = saveEventsFile('open', cfg, logFile);


### PR DESCRIPTION
Often, events are saved one-by-one during acquisition. This produces
lots of warnings because all the events before the one current one
are empty in the logFile. One would expect that these warnings can be
suppressed by setting cfg.verbose to 0. Simply adding this condition to
the saveEventsFile does the job.